### PR TITLE
Refactorisation : utilise le Network Requests Manager de QGIS à la place de requests

### DIFF
--- a/qtribu/plugin_main.py
+++ b/qtribu/plugin_main.py
@@ -214,7 +214,12 @@ class GeotribuPlugin:
         """
         try:
             qntwk = NetworkRequestsManager()
-            self.rss_rdr.read_feed(qntwk.get_from_source(headers=self.rss_rdr.HEADERS))
+            rss_feed_content = qntwk.get_from_source(
+                headers=self.rss_rdr.HEADERS,
+                response_expected_content_type="application/xml",
+            )
+
+            self.rss_rdr.read_feed(rss_feed_content)
             if not self.rss_rdr.latest_item:
                 raise Exception("No item found")
 

--- a/qtribu/toolbelt/log_handler.py
+++ b/qtribu/toolbelt/log_handler.py
@@ -128,10 +128,8 @@ class PlgLogger(logging.Handler):
             # QGIS or custom dialog
             if parent_location and isinstance(parent_location, QWidget):
                 msg_bar = parent_location.findChild(QgsMessageBar)
-                print(msg_bar)
 
             if not msg_bar:
-                print("use QGIS message bar as fallback")
                 msg_bar = iface.messageBar()
 
             # calc duration


### PR DESCRIPTION
Principal problème avec requests : c'est un package tiers donc il n'hérite pas des configurations réseau de QGIS (proxy, etc.)

Du coup, j'ai refacto le network manager pour qu'il soit plus générique.