### PR TITLE
Retirer tri des colonnes

### DIFF
--- a/qtribu/gui/dlg_contents.ui
+++ b/qtribu/gui/dlg_contents.ui
@@ -196,7 +196,7 @@
            <bool>true</bool>
           </property>
           <property name="sortingEnabled">
-           <bool>true</bool>
+           <bool>false</bool>
           </property>
           <property name="animated">
            <bool>true</bool>
@@ -214,7 +214,7 @@
            <number>64</number>
           </attribute>
           <attribute name="headerShowSortIndicator" stdset="0">
-           <bool>true</bool>
+           <bool>false</bool>
           </attribute>
           <column>
            <property name="text">


### PR DESCRIPTION
À l'heure actuelle d'aujourd'hui, les objets sont triés par défaut par la date qui est au format `%d %B` ce qui ne trie pas vraiment par ordre chronologique :

![image](https://github.com/geotribu/qtribu/assets/40383801/9d6bb648-9935-4f20-aefc-ecea16107219)

Plusieurs possibilités :

- retirer la possibilité de trier (ce qui est proposé par cette PR)
- mettre les dates au format `%m/%d` mais c'est moins zoli à mon avis