### PR TITLE
fix(web_viewer): switch from QtWebKit to QtWebEngine

### DIFF
--- a/qtribu/logic/__init__.py
+++ b/qtribu/logic/__init__.py
@@ -2,4 +2,3 @@
 from .custom_datatypes import RssItem  # noqa: F401
 from .rss_reader import RssMiniReader  # noqa: F401
 from .splash_changer import SplashChanger  # noqa: F401
-from .web_viewer import WebViewer  # noqa: F401

--- a/qtribu/logic/web_viewer.py
+++ b/qtribu/logic/web_viewer.py
@@ -19,7 +19,6 @@ from qgis.PyQt.QtGui import QDesktopServices
 
 QCoreApplication.setAttribute(Qt.AA_ShareOpenGLContexts)
 from qgis.PyQt.QtWebEngineWidgets import QWebEngineView as QWebView
-
 from qgis.PyQt.QtWidgets import QVBoxLayout, QWidget
 
 # project

--- a/qtribu/logic/web_viewer.py
+++ b/qtribu/logic/web_viewer.py
@@ -17,8 +17,11 @@ from typing import Optional
 from qgis.PyQt.QtCore import QCoreApplication, Qt
 from qgis.PyQt.QtGui import QDesktopServices
 
-QCoreApplication.setAttribute(Qt.AA_ShareOpenGLContexts)
-from qgis.PyQt.QtWebEngineWidgets import QWebEngineView as QWebView
+try:
+    QCoreApplication.setAttribute(Qt.AA_ShareOpenGLContexts)
+    from qgis.PyQt.QtWebEngineWidgets import QWebEngineView as QWebView
+except Exception:
+    from qgis.PyQt.QtWebKitWidgets import QWebView
 from qgis.PyQt.QtWidgets import QVBoxLayout, QWidget
 
 # project

--- a/qtribu/logic/web_viewer.py
+++ b/qtribu/logic/web_viewer.py
@@ -17,11 +17,8 @@ from typing import Optional
 from qgis.PyQt.QtCore import QCoreApplication, Qt
 from qgis.PyQt.QtGui import QDesktopServices
 
-try:
-    from qgis.PyQt.QtWebKitWidgets import QWebView
-except:
-    QCoreApplication.setAttribute(Qt.AA_ShareOpenGLContexts)
-    from PyQt.QtWebEngineWidgets import QWebEngineView as QWebView
+QCoreApplication.setAttribute(Qt.AA_ShareOpenGLContexts)
+from qgis.PyQt.QtWebEngineWidgets import QWebEngineView as QWebView
 
 from qgis.PyQt.QtWidgets import QVBoxLayout, QWidget
 

--- a/qtribu/logic/web_viewer.py
+++ b/qtribu/logic/web_viewer.py
@@ -16,13 +16,13 @@ from typing import Optional
 # PyQGIS
 from qgis.PyQt.QtCore import QCoreApplication, Qt
 from qgis.PyQt.QtGui import QDesktopServices
+from qgis.PyQt.QtWidgets import QVBoxLayout, QWidget
 
 try:
     QCoreApplication.setAttribute(Qt.AA_ShareOpenGLContexts)
     from qgis.PyQt.QtWebEngineWidgets import QWebEngineView as QWebView
 except Exception:
     from qgis.PyQt.QtWebKitWidgets import QWebView
-from qgis.PyQt.QtWidgets import QVBoxLayout, QWidget
 
 # project
 from qtribu.toolbelt import NetworkRequestsManager, PlgLogger, PlgOptionsManager

--- a/qtribu/toolbelt/commons.py
+++ b/qtribu/toolbelt/commons.py
@@ -1,7 +1,7 @@
 from qgis.PyQt.QtCore import QUrl
 from qgis.PyQt.QtGui import QDesktopServices
 
-from qtribu.logic import WebViewer
+from qtribu.logic.web_viewer import WebViewer
 
 web_viewer = WebViewer()
 


### PR DESCRIPTION
As discussed in https://github.com/geotribu/qtribu/pull/99, QtWebKit is deprecated. The previous fix was not portable. Even when QGIS has QtWebKitWidgets, it fails if not present on the system. This change adopts a more sustainable method using only QtWebEngineWidgets, which will also be available in Qt6.

Additionally, instead of calling PyQt (which can be PyQt5 or PyQt6 depending on the system), we now use the link provided by QGIS with qgis.PyQt.

Tested on FreeBSD and Windows (Osgeo4w). PyQt with QtWebEngine must be installed.

cc @kikislater 