### PR TITLE
fix(qchat): no notification on self message mention

### DIFF
--- a/qtribu/gui/dck_qchat.py
+++ b/qtribu/gui/dck_qchat.py
@@ -369,15 +369,18 @@ Rooms:
                 message["message"],
                 foreground_color=self.settings.qchat_color_mention,
             )
-            self.log(
-                message=self.tr("You were mentionned by {sender}: {message}").format(
-                    sender=message["author"], message=message["message"]
-                ),
-                application=self.tr("QChat"),
-                log_level=Qgis.Info,
-                push=PlgOptionsManager().get_plg_settings().notify_push_info,
-                duration=PlgOptionsManager().get_plg_settings().notify_push_duration,
-            )
+            if message["author"] != self.settings.author_nickname:
+                self.log(
+                    message=self.tr(
+                        "You were mentionned by {sender}: {message}"
+                    ).format(sender=message["author"], message=message["message"]),
+                    application=self.tr("QChat"),
+                    log_level=Qgis.Info,
+                    push=PlgOptionsManager().get_plg_settings().notify_push_info,
+                    duration=PlgOptionsManager()
+                    .get_plg_settings()
+                    .notify_push_duration,
+                )
         elif message["author"] == self.settings.author_nickname:
             item = self.create_message_item(
                 message["author"],


### PR DESCRIPTION
This PR avoids to send a QGIS message bar notification :
- when a user mention him.her.self
- when a user mention everybody with `@all`

Fix #195 