### PR TITLE
fix(qchat): allow to see registered users only if self registered

### DIFF
--- a/qtribu/gui/dck_qchat.py
+++ b/qtribu/gui/dck_qchat.py
@@ -709,6 +709,15 @@ Rooms:
         """
         Action called when the list users button is clicked
         """
+        if self.settings.qchat_incognito_mode:
+            QMessageBox.warning(
+                self,
+                self.tr("Registered users"),
+                self.tr(
+                    "You're using incognito mode. Please disable it to see registered users."
+                ),
+            )
+            return
         try:
             users = self.qchat_client.get_registered_users(self.current_room)
             QMessageBox.information(


### PR DESCRIPTION
Thought it would be nice to be able to see registered users only if you are also registered