### PR TITLE
feature(qchat): share QML style when sending geojson vector in ws

### DIFF
--- a/qtribu/gui/dck_qchat.py
+++ b/qtribu/gui/dck_qchat.py
@@ -1,7 +1,6 @@
 # standard
 import base64
 import json
-import os
 import tempfile
 from functools import partial
 from pathlib import Path
@@ -863,8 +862,8 @@ Rooms:
         Action called when the Send QGIS screenshot button is clicked
         """
 
-        sc_fp = os.path.join(tempfile.gettempdir(), "qgis_screenshot.png")
-        self.iface.mapCanvas().saveAsImage(sc_fp)
+        sc_fp = Path(tempfile.gettempdir()) / "qgis_screenshot.png"
+        self.iface.mapCanvas().saveAsImage(str(sc_fp))
         with open(sc_fp, "rb") as file:
             data = file.read()
             message = QChatImageMessage(
@@ -1033,6 +1032,15 @@ Visit the website ?
         exporter.setDestinationCrs(layer.crs())
         exporter.setTransformGeometries(True)
         geojson_str = exporter.exportFeatures(layer.getFeatures())
+
+        # save and read QML style to and from temp file
+        save_style_path = Path(tempfile.gettempdir()) / "qchat_layer_style.qml"
+        layer.saveNamedStyle(
+            str(save_style_path), categories=QgsMapLayer.AllStyleCategories
+        )
+        with open(save_style_path, "r", encoding="utf-8") as file:
+            qml_style = file.read()
+
         message = QChatGeojsonMessage(
             type=QCHAT_MESSAGE_TYPE_GEOJSON,
             author=self.settings.author_nickname,
@@ -1041,5 +1049,6 @@ Visit the website ?
             crs_wkt=layer.crs().toWkt(),
             crs_authid=layer.crs().authid(),
             geojson=json.loads(geojson_str),
+            style=qml_style,
         )
         self.qchat_ws.send_message(message)

--- a/qtribu/gui/dck_qchat.py
+++ b/qtribu/gui/dck_qchat.py
@@ -1033,7 +1033,8 @@ Visit the website ?
         # save and read QML style to and from temp file
         save_style_path = Path(tempfile.gettempdir()) / "qchat_layer_style.qml"
         layer.saveNamedStyle(
-            str(save_style_path), categories=QgsMapLayer.AllStyleCategories
+            str(save_style_path),
+            categories=QgsMapLayer.StyleCategory.AllStyleCategories,
         )
         with open(save_style_path, "r", encoding="utf-8") as file:
             qml_style = file.read()

--- a/qtribu/gui/qchat_tree_widget_items.py
+++ b/qtribu/gui/qchat_tree_widget_items.py
@@ -243,7 +243,7 @@ class QChatGeojsonTreeWidgetItem(QChatTreeWidgetItem):
             layer.loadNamedStyle(
                 str(save_style_path),
                 loadFromLocalDb=False,
-                categories=QgsMapLayer.AllStyleCategories,
+                categories=QgsMapLayer.StyleCategory.AllStyleCategories,
             )
             QgsProject.instance().addMapLayer(layer)
 

--- a/qtribu/logic/qchat_messages.py
+++ b/qtribu/logic/qchat_messages.py
@@ -56,6 +56,7 @@ class QChatGeojsonMessage(QChatMessage):
     crs_wkt: str
     crs_authid: str
     geojson: dict
+    style: Optional[str]
 
 
 @dataclass(init=True, frozen=True)

--- a/qtribu/logic/qchat_websocket.py
+++ b/qtribu/logic/qchat_websocket.py
@@ -32,6 +32,7 @@ from qtribu.logic.qchat_messages import (
     QChatUncompliantMessage,
 )
 from qtribu.toolbelt import PlgLogger
+from qtribu.toolbelt.exceptions import QChatMessageCanNotBeParsedException
 
 
 class EnhancedJSONEncoder(JSONEncoder):
@@ -121,23 +122,33 @@ class QChatWebsocket(QObject):
             )
             return
         msg_type = message["type"]
-        if msg_type == QCHAT_MESSAGE_TYPE_UNCOMPLIANT:
-            self.uncompliant_message_received.emit(QChatUncompliantMessage(**message))
-        elif msg_type == QCHAT_MESSAGE_TYPE_TEXT:
-            self.text_message_received.emit(QChatTextMessage(**message))
-        elif msg_type == QCHAT_MESSAGE_TYPE_IMAGE:
-            self.image_message_received.emit(QChatImageMessage(**message))
-        elif msg_type == QCHAT_MESSAGE_TYPE_NB_USERS:
-            self.nb_users_message_received.emit(QChatNbUsersMessage(**message))
-        elif msg_type == QCHAT_MESSAGE_TYPE_NEWCOMER:
-            self.newcomer_message_received.emit(QChatNewcomerMessage(**message))
-        elif msg_type == QCHAT_MESSAGE_TYPE_EXITER:
-            self.exiter_message_received.emit(QChatExiterMessage(**message))
-        elif msg_type == QCHAT_MESSAGE_TYPE_LIKE:
-            self.like_message_received.emit(QChatLikeMessage(**message))
-        elif msg_type == QCHAT_MESSAGE_TYPE_GEOJSON:
-            self.geojson_message_received.emit(QChatGeojsonMessage(**message))
-        elif msg_type == QCHAT_MESSAGE_TYPE_CRS:
-            self.crs_message_received.emit(QChatCrsMessage(**message))
-        elif msg_type == QCHAT_MESSAGE_TYPE_BBOX:
-            self.bbox_message_received.emit(QChatBboxMessage(**message))
+        try:
+            if msg_type == QCHAT_MESSAGE_TYPE_UNCOMPLIANT:
+                self.uncompliant_message_received.emit(
+                    QChatUncompliantMessage(**message)
+                )
+            elif msg_type == QCHAT_MESSAGE_TYPE_TEXT:
+                self.text_message_received.emit(QChatTextMessage(**message))
+            elif msg_type == QCHAT_MESSAGE_TYPE_IMAGE:
+                self.image_message_received.emit(QChatImageMessage(**message))
+            elif msg_type == QCHAT_MESSAGE_TYPE_NB_USERS:
+                self.nb_users_message_received.emit(QChatNbUsersMessage(**message))
+            elif msg_type == QCHAT_MESSAGE_TYPE_NEWCOMER:
+                self.newcomer_message_received.emit(QChatNewcomerMessage(**message))
+            elif msg_type == QCHAT_MESSAGE_TYPE_EXITER:
+                self.exiter_message_received.emit(QChatExiterMessage(**message))
+            elif msg_type == QCHAT_MESSAGE_TYPE_LIKE:
+                self.like_message_received.emit(QChatLikeMessage(**message))
+            elif msg_type == QCHAT_MESSAGE_TYPE_GEOJSON:
+                self.geojson_message_received.emit(QChatGeojsonMessage(**message))
+            elif msg_type == QCHAT_MESSAGE_TYPE_CRS:
+                self.crs_message_received.emit(QChatCrsMessage(**message))
+            elif msg_type == QCHAT_MESSAGE_TYPE_BBOX:
+                self.bbox_message_received.emit(QChatBboxMessage(**message))
+        except KeyError:
+            text = self.tr(
+                "Unintelligible message received. Please make sure you are using the latest plugin version. (type={type})"
+            ).format(type=msg_type)
+            message = QChatUncompliantMessage(reason=text)
+            self.uncompliant_message_received.emit(message)
+            raise QChatMessageCanNotBeParsedException(message=text)

--- a/qtribu/toolbelt/commons.py
+++ b/qtribu/toolbelt/commons.py
@@ -1,5 +1,5 @@
 # standard
-import os
+from pathlib import Path
 
 # 3rd party
 from PyQt5.QtMultimedia import QMediaContent, QMediaPlayer  # noqa QGS103
@@ -61,7 +61,7 @@ def play_resource_sound(resource: str, volume: int) -> None:
     The file_name param must be the name (without extension) of a .mp3 audio file inside resources/sounds folder
     """
     file_path = str(DIR_PLUGIN_ROOT / f"resources/sounds/{resource}.mp3")
-    if not os.path.exists(file_path):
+    if not Path(file_path).is_file():
         raise FileNotFoundError(
             f"File '{resource}.wav' not found in resources/sounds folder"
         )

--- a/qtribu/toolbelt/exceptions.py
+++ b/qtribu/toolbelt/exceptions.py
@@ -1,0 +1,2 @@
+class QChatMessageCanNotBeParsedException(Exception):
+    pass


### PR DESCRIPTION
This PR will allow to share the QML style of a vector layer sent throught websocket on QChat.

Testable on `staging.gischat.geotribu.net` only ATM.