### PR TITLE
update(docs): add install instructions for qgis4 and remove qchat deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 ## 1.4.3 - 2026-02-09
 
 * Feature: expose settings as environement variables by @Guts in <https://github.com/geotribu/qtribu/pull/282>
-* fix(forms): replace latest refs to Twitter by Bluseksy by @Guts in <https://github.com/geotribu/qtribu/pull/286>
+* fix(forms): replace latest refs to Twitter by Bluesky by @Guts in <https://github.com/geotribu/qtribu/pull/286>
 
 ## 1.4.2 - 2026-01-24
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -4,7 +4,7 @@
 
 Certaines fonctionnalités du plugin reposent sur des dépendances logicielles tierces non incluses dans le packaging de QGIS sur certaines plateformes :
 
-- QGISChat: (Py)QtMutimedia, (Py)QtWebEngine, (Py)QtWebSockets,
+- Navigateur web intégré : (Py)QtWebEngine
 
 ### Linux
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -8,13 +8,19 @@ Certaines fonctionnalités du plugin reposent sur des dépendances logicielles t
 
 ### Linux
 
-> Par exemple sur Ubuntu 22.04. Adapter à votre distribution.
+> Par exemple sur Ubuntu 24.04. Adapter à votre distribution.
 
-Ouvrir un terminal et exécuter la commande suivante :
+- Avec QGIS 3 (Qt 5), ouvrir un terminal et exécuter la commande suivante :
 
-```sh
-sudo apt install python3-pyqt5.qtmultimedia python3-pyqt5.qtwebengine python3-pyqt5.qtwebsockets
-```
+    ```sh
+    sudo apt install python3-pyqt5.qtwebengine
+    ```
+
+- Avec QGIS 4 (Qt 6), ouvrir un terminal et exécuter la commande suivante :
+
+    ```sh
+    sudo apt install python3-pyqt6.qtwebengine
+    ```
 
 ----
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -22,6 +22,12 @@ Certaines fonctionnalités du plugin reposent sur des dépendances logicielles t
     sudo apt install python3-pyqt6.qtwebengine
     ```
 
+### Windows et macOS
+
+Les installeurs de QGIS 3 (Qt 5) incluent déjà les dépendances nécessaires pour le navigateur web intégré.
+
+En revanche, les installeurs de QGIS 4 (Qt 6) ne les incluent pas à date de la 4.0.1. En effet, le paquet `python3-pyqtwebengine` disponible dans l'OSGEo4W est toujours celui basé sur PyQt5 (voir [le sujet sur le plugin qgis2threjs](https://github.com/minorua/Qgis2threejs/wiki/How-to-use-Qt-WebEngine-view-with-Qgis2threejs)). Le navigateur système est utilisé par défaut de façon transparente.
+
 ----
 
 ## Version stable (recommandée)

--- a/qtribu/toolbelt/commons.py
+++ b/qtribu/toolbelt/commons.py
@@ -41,7 +41,7 @@ def open_url_in_webviewer(url: str, window_title: str) -> None:
             message="The embedded webviewer is not avaible, probably because "
             "of unfilled system dependencies (QtWebEngine). Using default system "
             "browser as fallback.",
-            log_level=Qgis.MessageLevel.Critical,
+            log_level=Qgis.MessageLevel.Warning,
         )
         open_url_in_browser(url=url)
         return


### PR DESCRIPTION
And remove system dependencies related to QChat.

> [!NOTE]
> Si on vire le support de QGIS < 3.42, on pourra simplifier avec https://qgis.org/pyqgis/master/gui/QgsGui.html#qgis.gui.QgsGui.hasWebEngine
