### PR TITLE
fix(rss-reader): remove duplicate rss item enclosure retrieval

### DIFF
--- a/qtribu/logic/news_feed/rss_reader.py
+++ b/qtribu/logic/news_feed/rss_reader.py
@@ -155,7 +155,7 @@ class RssMiniReader:
         for item in items:
             try:
                 # filter on included pattern
-                if not any([i in item.find("link").text for i in self.PATTERN_INCLUDE]):
+                if not any(i in item.find("link").text for i in self.PATTERN_INCLUDE):
                     self.log(
                         message="Item ignored because unmatches the include pattern: {}".format(
                             item.find("title").text

--- a/qtribu/logic/news_feed/rss_reader.py
+++ b/qtribu/logic/news_feed/rss_reader.py
@@ -176,10 +176,19 @@ class RssMiniReader:
                     title=item.find("title").text,
                     url=item.find("link").text,
                 )
-                if item_enclosure := item.find("enclosure"):
+                if (item_enclosure := item.find("enclosure")) is not None:
                     feed_item_obj.image_length = item_enclosure.attrib.get("length")
                     feed_item_obj.image_type = item_enclosure.attrib.get("type")
                     feed_item_obj.image_url = item_enclosure.attrib.get("url")
+                else:
+                    self.log(
+                        message=self.tr(
+                            "DEBUG: No illustration (enclosure) found of this feed item: {}.".format(
+                                item.find("title").text
+                            )
+                        ),
+                        log_level=Qgis.MessageLevel.NoLevel,
+                    )
 
                 # add items to the feed
                 feed_items.append(feed_item_obj)
@@ -257,7 +266,7 @@ class RssMiniReader:
 
         # get latest QGIS item id
         latest_geotribu_article = self.latest_item
-        item_id = 99
+        item_id = 999
 
         qsettings.setValue(
             key=f"news-feed/items/httpsfeedqgisorg/entries/items/{item_id}/title",
@@ -281,6 +290,11 @@ class RssMiniReader:
         qsettings.setValue(
             key=f"news-feed/items/httpsfeedqgisorg/entries/items/{item_id}/link",
             value=latest_geotribu_article.url,
+            section=QgsSettings.Section.App,
+        )
+        qsettings.setValue(
+            key=f"news-feed/items/httpsfeedqgisorg/entries/items/{item_id}/sticky",
+            value=True,
             section=QgsSettings.Section.App,
         )
 

--- a/qtribu/logic/news_feed/rss_reader.py
+++ b/qtribu/logic/news_feed/rss_reader.py
@@ -173,9 +173,6 @@ class RssMiniReader:
                     or None,
                     date_pub=parsedate(item.find("pubDate").text),
                     guid=item.find("guid").text,
-                    image_length=item.find("enclosure").attrib.get("length"),
-                    image_type=item.find("enclosure").attrib.get("type"),
-                    image_url=item.find("enclosure").attrib.get("url"),
                     title=item.find("title").text,
                     url=item.find("link").text,
                 )


### PR DESCRIPTION
Ça devrait corriger le décalage entre l'image affichée et le contenu.